### PR TITLE
Task 8: Add Connect Wallet Button to Home Page

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,12 @@
+'use client';
+
+import { ConnectButton } from '@rainbow-me/rainbowkit';
+
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center p-24">
-      <h1 className="text-4xl font-bold">Ultra-Simple Commerce</h1>
-      <p className="mt-4 text-gray-600">Coming soon...</p>
+      <h1 className="text-4xl font-bold mb-8">Ultra-Simple Commerce</h1>
+      <ConnectButton />
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Add RainbowKit ConnectButton to the home page.

**Issue:** Closes #11
**Epic:** #3

## Changes

- Add `ConnectButton` from RainbowKit to home page
- Add `'use client'` directive (required because ConnectButton uses React hooks)
- Remove "Coming soon..." placeholder

## Why `'use client'`?

The `ConnectButton` component uses React hooks internally (`useState`, `useEffect`) for managing wallet connection state. These hooks only work in Client Components.

## Test Plan

- [x] `pnpm typecheck` passes
- [x] "Connect Wallet" button visible on home page
- [x] Clicking button opens RainbowKit modal with wallet options

🤖 Generated with [Claude Code](https://claude.com/claude-code)